### PR TITLE
 upgrade SKU to Standard

### DIFF
--- a/FortiWeb/FortiWeb-VariableHA-2-NIC/publicip-new.json
+++ b/FortiWeb/FortiWeb-VariableHA-2-NIC/publicip-new.json
@@ -90,6 +90,9 @@
           "provider": "[toUpper(parameters('FortinetTags').provider)]"
         },
         "location": "[parameters('location')]",
+	"sku": {
+          "name": "Standard"
+        },
         "dependsOn": [
           "[variables('publicIPID')]"
         ],


### PR DESCRIPTION
add property to upgrade the SKU to Standard to prevent the following error message:
"Resource health status is not available for Load Balancer using current service plan. To enable health status, consider upgrading to a Standard service plan. "